### PR TITLE
Update gatsby-browser.js

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,11 +1,11 @@
-exports.onInitialClientRender = (n, config) => {
+exports.onInitialClientRender = function(n, config) {
   window.mermaid_config = { theme: config.theme || 'default', startOnLoad: true }
   // load initial script
   const s = document.createElement('script')
   s.setAttribute('src', 'https://unpkg.com/mermaid@7.1.0/dist/mermaid.min.js')
   document.head.appendChild(s)
   // XXX: ugly hack because onRouteUpdate doesn't know when the react is done
-  setInterval(() => {
+  setInterval(function() {
     window.mermaid.init(undefined, document.getElementsByClassName('mermaid'))
   }, 200)
 }


### PR DESCRIPTION
Gatsby depends on a version of Uglify which [does not support ES6 syntax](https://github.com/mishoo/UglifyJS2/issues/448). This causes a crash when running this plugin with Gatsby's `deploy` script with this plugin installed (`gatsby develop` builds are unaffected).

This PR rolls two function calls back to ES5 syntax, which solves the crash.

I totally acknowledge that this is a fix for a bug caused by a Gatsby dependency, and not a bug in this plugin. But the fix is very simple in this codebase, versus a potentially breaking change in Gatsby's.